### PR TITLE
Add count mode to GraphQL auth checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ returning these types, run the script with the `--inverse` option:
 python3 check_auth.py --inverse
 ```
 
+To output only a summary count of how many field usages include an
+`authorize:` argument versus those that do not, use the `--count` option:
+
+```bash
+python3 check_auth.py --count
+```
+
 The script prints a JSON object describing occurrences where fields return
 types listed in `noauthtypes.txt`. By default it reports fields that
 lack an `authorize:` argument. When `--inverse` is used, it instead


### PR DESCRIPTION
## Summary
- add a `--count` option to `check_auth.py` to get summary statistics
- document new option in README

## Testing
- `python3 check_auth.py --count`
- `python3 check_auth.py | head -n 20`
- `python3 check_auth.py --inverse | head -n 10`


------
https://chatgpt.com/codex/tasks/task_e_6886891f5a2483249f270d7d28e63da3